### PR TITLE
Allow "Connection established" in check_reason

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -64,7 +64,7 @@ fn check_code(response: &Response<'_, '_>) -> Result<(), HttpError> {
 fn check_reason(response: &Response<'_, '_>) -> Result<(), HttpError> {
     match response.reason {
         Some(reason) => {
-            if reason == "Connection Established" {
+            if reason == "Connection Established" || reason == "Connection established"{
                 Ok(())
             } else {
                 Err(HttpError::HttpReasonConnectionEstablished(

--- a/src/response.rs
+++ b/src/response.rs
@@ -64,7 +64,7 @@ fn check_code(response: &Response<'_, '_>) -> Result<(), HttpError> {
 fn check_reason(response: &Response<'_, '_>) -> Result<(), HttpError> {
     match response.reason {
         Some(reason) => {
-            if reason == "Connection Established" || reason == "Connection established"{
+            if reason == "Connection Established" || reason == "Connection established" {
                 Ok(())
             } else {
                 Err(HttpError::HttpReasonConnectionEstablished(


### PR DESCRIPTION
First of all, thanks for the library. 

I've tried this with [proxy.py](https://github.com/abhinavsingh/proxy.py) and I've found that it seems the message is "Connection established" rather than "Connection Established" at least for proxy.py.

https://github.com/abhinavsingh/proxy.py/blob/c09fc8627727fed98dd1bdde8321a6efa36a8fcd/proxy/http/proxy/server.py#L106

Additionally, I wonder why you check the message string itself. I feel it's a bit fragile so could you tell me the reason for this?