### PR TITLE
[Suggestion] Use "Caret requirements" instead of "Tilda requirements"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,24 +22,24 @@ runtime-tokio = ["tokio"]
 runtime-async-std = ["async-std"]
 
 [dependencies]
-thiserror = "~1.0.30"
-httparse = "~1.5.1"
+thiserror = "1.0.30"
+httparse = "1.5.1"
 
 [dependencies.tokio]
-version = "~1.15.0"
+version = "1.15.0"
 features = ["io-util"]
 optional = true
 
 [dependencies.async-std]
-version = "~1.10.0"
+version = "1.10.0"
 optional = true
 
 [dependencies.base64]
-version = "~0.13.0"
+version = "0.13.0"
 optional = true
 
 [dev-dependencies.tokio]
-version = "~1.15.0"
+version = "1.15.0"
 features = ["net", "rt-multi-thread", "macros"]
 
 [[example]]


### PR DESCRIPTION
Because `~` is too strict and we always hit unnecessary dependency confliction like

![CleanShot 2022-02-15 at 15 42 37](https://user-images.githubusercontent.com/546312/154007989-de0f8919-fc51-4bcb-a772-1dd07a5767c3.png)

I know that you prefer `~` (https://github.com/LinkTed/async-http-proxy/pull/3#issuecomment-884125155) but if we use "Caret requirements", we don't need PRs like #4 unless there are real break changes.